### PR TITLE
Correcting test errors and adding browser support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# WebStorm IDE Folder
+.idea
+
 lib-cov
 *.seed
 *.log
@@ -16,3 +19,7 @@ npm-debug.log
 
 /node_modules
 /lib-cov
+
+# npm run browser will generate this file. I would recommend putting this in a dist/ directory once your project grows.
+# This file should not be checked into git since it should be generated. However it should be included in the npm package.
+/lib/maybe.browser.js

--- a/package.json
+++ b/package.json
@@ -1,25 +1,33 @@
 {
-  "name":         "maybe",
-  "version":      "0.0.2",
-  "description":  "Maybe monad for JavaScript",
-  "main":         "lib/maybe.js",
+  "name": "maybe",
+  "version": "0.0.2",
+  "description": "Maybe monad for JavaScript",
+  "main": "lib/maybe.js",
   "repository": {
-    "type":       "git",
-    "url":        "https://github.com/chrissrogers/maybe.git"
+    "type": "git",
+    "url": "https://github.com/chrissrogers/maybe.git"
   },
-  "bugs":         "https://github.com/chrissrogers/maybe/issues",
+  "bugs": "https://github.com/chrissrogers/maybe/issues",
   "scripts": {
-    "test":       "MAYBE_COV=1 node_modules/.bin/mocha --require should --ui bdd --reporter mocha-lcov-reporter --recursive | ./node_modules/.bin/coveralls"
+    "test": "MAYBE_COV=1 node_modules/.bin/mocha --require should --ui bdd --reporter mocha-lcov-reporter --recursive | ./node_modules/.bin/coveralls",
+    "browser": "node_modules/.bin/browserify lib/maybe.js -o lib/maybe.browser.js"
   },
-  "keywords":   [ "maybe", "monad", "type", "haskell", "null" ],
+  "keywords": [
+    "maybe",
+    "monad",
+    "type",
+    "haskell",
+    "null"
+  ],
   "devDependencies": {
-    "mocha":               "1.x",
+    "browserify": "^13.0.0",
+    "coveralls": "*",
+    "jscoverage": "*",
+    "lodash": "*",
+    "mocha": "1.x",
     "mocha-lcov-reporter": "*",
-    "should":              "1.x",
-    "lodash":              "*",
-    "jscoverage":          "*",
-    "coveralls":           "*"
+    "should": "1.x"
   },
-  "author":       "Christopher Rogers",
-  "license":      "MIT"
+  "author": "Christopher Rogers",
+  "license": "MIT"
 }

--- a/test/maybe.js
+++ b/test/maybe.js
@@ -1,6 +1,7 @@
 
 // util
-var _ = require('lodash');
+var _ = require('lodash'),
+    should = require('should');
 
 // test data
 var justs      = [true, false, 0, '', [], {}],
@@ -24,7 +25,6 @@ if (process.env.MAYBE_COV) {
     });
 
   });
-
 }
 
 describe('Maybe', function () {


### PR DESCRIPTION
This is in response to issue #5 requesting browser support.

I have added a new npm "script" `npm run browser` that will generate a browser compatible version of the `lib/maybe.js` file into `lib/maybe.browser.js`. Feel free to fine tune the name and location of this file to your liking. The script will continue to work even as you add more js files. Though you will need to remember to run this command before pushing to npm so that the file includes the latest code. I also recommend perhaps moving this file to a `dist` directory or something of the like. The file can also be safely minified if you choose to deliver the quickest download speed to the browser.

In addition there were failing tests due to a missing `var should = require('should');` statement in the `test/maybe.js` file. Corrected that.

I also added the `lib/maybe.browser.js` generated file to the `.gitignore` as this is a generated file and should not be checked into source control.

It also looks like running `npm install` to add the browserify package re-parsed and removed your alignments in the `package.json`. Just wanted to add that that wasn't a change that I made on purpose due to opinions or anything.
